### PR TITLE
Docs: Added SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security and Responsible Disclosure Policy
+
+The Centers for Medicare & Medicaid Services is committed to ensuring the security of the American public by protecting their information from unwarranted disclosure. We want security researchers to feel comfortable reporting vulnerabilities they have discovered so we can fix them and keep our users safe. We developed our disclosure policy to reflect our values and uphold our sense of responsibility to security researchers who share their expertise with us in good faith.
+
+*Submit a vulnerability:* Unfortunately, we cannot accept secure submissions via
+email or via GitHub Issues. Please use our website to submit vulnerabilities at
+[https://hhs.responsibledisclosure.com](https://hhs.responsibledisclosure.com).
+HHS maintains an acknowledgements page to recognize your efforts on behalf of
+the American public, but you are also welcome to submit anonymously.
+
+Review the HHS Disclosure Policy and websites in scope:
+[https://www.hhs.gov/vulnerability-disclosure-policy/index.html](https://www.hhs.gov/vulnerability-disclosure-policy/index.html).
+
+This policy describes *what systems and types of research* are covered under this
+policy, *how to send* us vulnerability reports, and *how long* we ask security
+researchers to wait before publicly disclosing vulnerabilities.
+
+If you have other cybersecurity related questions, please contact us at
+[csirc@hhs.gov](mailto:csirc@hhs.gov).


### PR DESCRIPTION
## Docs: Added SECURITY.md

## Problem

Before this project can be released as an open source repository, this project must include information about CMS' security policies.

## Solution

Added SECURITY.md which outlines CMS' Security and Responsible Disclosure Policy as well as the vulnerability submission process.