### PR TITLE
Archival: Add workflow to archive repository

### DIFF
--- a/.github/workflows/archive-repo.yml
+++ b/.github/workflows/archive-repo.yml
@@ -1,0 +1,23 @@
+name: Archive repository
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  run-repo-sunsetter:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Run repo-sunsetter
+        id: archive
+        uses: DSACMS/repo-sunsetter@v1.0.0
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          USE_MATURITY_MODEL_TIERS: "true"


### PR DESCRIPTION
## Problem
We would like to archive this repository by using the repo-sunsetter GitHub Action.

## Solution
Add `archive-repo.yml`, a new workflow file that runs repo-sunsetter

## Result
The repository now contains the workflow to run repo-sunsetter. Once merged, we can run the workflow and kick off the process to prepare the repository for archival. repo-sunsetter will do 3 things: 
- Post an issue with archival preparation tasks
- Adds an archival notice to the README
- Updates the repository's metadata in the code.json file